### PR TITLE
Fix notice due to missing translation key

### DIFF
--- a/statscheckup.php
+++ b/statscheckup.php
@@ -156,7 +156,7 @@ class statscheckup extends Module
             'DESCRIPTIONS' => array('name' => $this->trans('Descriptions', array(), 'Modules.Statscheckup.Admin'), 'text' => $this->trans('chars (without HTML)', array(), 'Modules.Statscheckup.Admin')),
             'IMAGES' => array('name' => $this->trans('Images', array(), 'Admin.Global'), 'text' => $this->trans('images', array(), 'Admin.Global')),
             'SALES' => array('name' => $this->trans('Sales', array(), 'Admin.Global'), 'text' => $this->trans('orders / month', array(), 'Modules.Statscheckup.Admin')),
-            'STOCK' => array('name' => $this->trans('Available quantity for sale', array(), 'Admin.Global'))
+            'STOCK' => array('name' => $this->trans('Available quantity for sale', array(), 'Admin.Global'), 'text' => $this->trans('items', array(), 'Modules.Statscheckup.Admin'))
         );
 
         $this->html = '


### PR DESCRIPTION
**Describe the bug**
Notice of undefined index on translation array due to https://github.com/PrestaShop/statscheckup/commit/59eec4b40066e381427d509e3305b8380c6fad71#diff-f58ed5b03c11808ab9cde28a3b39a97bR159

**To Reproduce**
Steps to reproduce the behavior:

1. Enable debug mode
2. Go to backoffice
3. Click on Stats
4. Click on Catalog evaluation
5. See error

**Screenshots**
Error
![issue-statscheckup](https://user-images.githubusercontent.com/5262628/49934429-a0d79080-fece-11e8-9461-2f288d5eef48.png)
Before
![issue-statscheckup-before](https://user-images.githubusercontent.com/5262628/49934541-f449de80-fece-11e8-8e29-e69b8722a168.png)
After
![issue-statscheckup-after](https://user-images.githubusercontent.com/5262628/49934555-f90e9280-fece-11e8-8159-56310fe299f4.png)

**Additionnal information**
PrestaShop version: 1.7.4.4
PHP version: 7.1

**Fixed issues**
https://github.com/PrestaShop/PrestaShop/issues/9643
https://github.com/PrestaShop/PrestaShop/issues/9899
https://github.com/PrestaShop/PrestaShop/issues/11761