### PR TITLE
Remove no longer reported test ignored error

### DIFF
--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -4,4 +4,3 @@ includes:
 parameters:
   ignoreErrors:
     - '#Access to an undefined property Cookie::\$checkup_order.#'
-    - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, string given.#'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Error about addSqlRestriction is no longer reported and test is failing because of it. This removes this exclusion.
| Type?         | 
| BC breaks?    | 
| Deprecations? | 
| Fixed ticket? | 
| How to test?  | 