### PR TITLE
Provide absolute URL to fix routing issues

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -71,14 +71,14 @@ jobs:
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/statscheckup.php
+++ b/statscheckup.php
@@ -110,7 +110,6 @@ class statscheckup extends Module
             1 => '<img src="../modules/' . $this->name . '/img/orange.png" alt="' . $this->trans('Average', [], 'Modules.Statscheckup.Admin') . '" />',
             2 => '<img src="../modules/' . $this->name . '/img/green.png" alt="' . $this->trans('Good', [], 'Modules.Statscheckup.Admin') . '" />',
         ];
-        $token_products = Tools::getAdminToken('AdminProducts' . (int) Tab::getIdFromClassName('AdminProducts') . (int) Context::getContext()->employee->id);
         $divisor = 4;
         $totals = ['products' => 0, 'active' => 0, 'images' => 0, 'sales' => 0, 'stock' => 0];
         foreach ($languages as $language) {
@@ -163,7 +162,7 @@ class statscheckup extends Module
 		<div class="panel-heading">'
             . $this->displayName . '
 		</div>
-		<form action="' . Tools::safeOutput(AdminController::$currentIndex . '&token=' . Tools::getValue('token') . '&module=' . $this->name) . '" method="post" class="checkup form-horizontal">
+		<form action="' . Tools::safeOutput($this->context->link->getAdminLink('AdminStats', true) . '&module=' . $this->name) . '" method="post" class="checkup form-horizontal">
 			<table class="table checkup">
 				<thead>
 					<tr>
@@ -205,7 +204,7 @@ class statscheckup extends Module
 				<i class="icon-save"></i> ' . $this->trans('Save', [], 'Admin.Actions') . '
 			</button>
 		</form>
-		<form action="' . Tools::safeOutput(AdminController::$currentIndex . '&token=' . Tools::getValue('token') . '&module=' . $this->name) . '" method="post" class="form-horizontal alert">
+		<form action="' . Tools::safeOutput($this->context->link->getAdminLink('AdminStats', true) . '&module=' . $this->name) . '" method="post" class="form-horizontal alert">
 			<div class="row">
 				<div class="col-lg-12">
 					<label class="control-label pull-left">' . $this->trans('Order by', [], 'Modules.Statscheckup.Admin') . '</label>
@@ -270,7 +269,7 @@ class statscheckup extends Module
             $this->html .= '
 				<tr>
 					<td>' . $row['id_product'] . '</td>
-					<td><a href="' . Tools::safeOutput('index.php?controller=AdminProducts&updateproduct&id_product=' . $row['id_product'] . '&token=' . $token_products) . '">' . Tools::substr($row['name'], 0, 42) . '</a></td>
+					<td><a href="' . Tools::safeOutput($this->context->link->getAdminLink('AdminProducts', true) . '&updateproduct&id_product=' . $row['id_product']) . '">' . Tools::substr($row['name'], 0, 42) . '</a></td>
 					<td class="center">' . $array_colors[$scores['active']] . '</td>';
             foreach ($languages as $language) {
                 if (isset($row['desclength_' . $language['iso_code']])) {


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Provide absolute URL to fix routing issues. Fixes potential issues coming from relative URLs not being reliable after symfony migration. See https://github.com/PrestaShop/PrestaShop/issues/39185. cc @Touxten 
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39185
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Just test the module can be configured correctly and loads in the backoffice, so we didn't break anything or have some typo. (On nginx server, this could be problematic.)
